### PR TITLE
chore(#9): add completion report system with Phase 1-4 retroactive reports

### DIFF
--- a/.sisyphus/reports/README.md
+++ b/.sisyphus/reports/README.md
@@ -1,0 +1,86 @@
+# Completion Report 시스템 — 프로세스 규약
+
+## 목적
+
+플랜이 완료될 때마다 구조화된 마무리 레포트를 `.sisyphus/reports/{plan-name}.md`에 생성한다.
+두 가지 역할을 겸한다:
+
+1. **세션 복구**: 세션이 죽거나 컨텍스트가 초기화됐을 때 새 세션이 즉시 현황 파악
+2. **작업 아카이빙**: 나중에 "Phase N에서 뭘 했지?" 를 되돌아볼 때 참조
+
+---
+
+## 생성 시점
+
+**플랜 완료 시 (PR 머지 직후)**. 구체적으로:
+
+- 모든 새 플랜의 **마지막 태스크**에 "Completion Report 생성" 태스크를 반드시 포함한다
+- 레포트 생성은 PR 머지 직전 또는 직후에 수행 (머지 커밋 정보가 필요하므로 직후 권장)
+- 이 과정은 **코드/스크립트가 아닌 프로세스 규약(convention)** — 에이전트가 수동으로 수행
+
+---
+
+## 파일 명명 규칙
+
+```
+.sisyphus/reports/{plan-name}.md
+```
+
+- plan 파일(`.sisyphus/plans/{plan-name}.md`)과 **1:1 대응**
+- 날짜 접두사, phase 번호 접두사 사용 금지
+- 예: `docs-foundation.md`, `viral-strategy.md`
+
+---
+
+## 6개 필수 섹션 및 데이터 소스
+
+| 섹션 | 데이터 소스 |
+|------|-----------|
+| 사용자 요청 원문 | plan 파일의 `### Original Request` 섹션 |
+| 산출물 | plan 파일 `Deliverables` + `git diff --stat` + `gh pr view {N} --json files` |
+| 핵심 결정사항 | `notepads/{plan}/decisions.md` + plan 파일 `### Interview Summary` |
+| Git 상태 스냅샷 | `git log --oneline` + `gh pr view {N} --json title,mergedAt,mergeCommit` |
+| 다음 단계 | plan 파일 기재사항 + 자연스러운 후속 작업 추론. 소급 레포트는 "실제로 한 것" 기준 |
+| 에이전트 세션 ID | `boulder.json` + notepads에 기록된 세션 |
+
+---
+
+## 데이터 없음 처리 규칙
+
+**추정/날조 금지.** 데이터가 없으면 아래 형식으로 표기:
+
+```
+데이터 없음 ({이유})
+```
+
+예시:
+
+- `데이터 없음 (세션 추적 시작 전)`
+- `데이터 없음 (notepad 디렉토리 미존재)`
+
+---
+
+## 미완료/취소 플랜 처리
+
+- **Status** 필드: `cancelled` 또는 `paused`로 표기
+- 중단 사유 기록 (`## 중단 사유` 섹션 추가)
+- PR이 없으면 Git 상태 섹션에 `PR: 생성 안 됨` 표기
+
+---
+
+## 템플릿
+
+레포트 작성 시 `.sisyphus/reports/_template.md`를 기반으로 한다.
+섹션을 삭제하거나 이름을 바꾸지 않는다.
+
+---
+
+## 현재까지 생성된 레포트
+
+| Phase | Plan | 레포트 |
+|-------|------|--------|
+| 1 | docs-foundation | [docs-foundation.md](./docs-foundation.md) |
+| 2 | validation | [validation.md](./validation.md) |
+| 3 | infrastructure-research | [infrastructure-research.md](./infrastructure-research.md) |
+| 4 | viral-strategy | [viral-strategy.md](./viral-strategy.md) |
+| 5 | completion-reports | [completion-reports.md](./completion-reports.md) |

--- a/.sisyphus/reports/_template.md
+++ b/.sisyphus/reports/_template.md
@@ -1,0 +1,65 @@
+# Completion Report: {plan-name}
+
+> **Phase**: {N}
+> **Plan**: .sisyphus/plans/{plan-name}.md
+> **Status**: completed | cancelled | paused
+> **Period**: {시작일} ~ {완료일}
+> **PR**: #{N} (merged {날짜})
+> **Issue**: #{N}
+
+---
+
+## 사용자 요청 원문
+
+> {사용자가 실제로 말한 것 그대로. 여러 턴이면 번호 매기기}
+
+---
+
+## 산출물
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `{path}` | 신규 / 수정 | {설명} |
+
+### 커밋 이력
+
+| 해시 | 메시지 |
+|------|--------|
+| `{hash}` | {message} |
+
+---
+
+## 핵심 결정사항
+
+| 결정 | 상태 | 근거 요약 |
+|------|------|----------|
+| {결정 내용} | [DECIDED] | {근거 한 줄 요약} |
+
+---
+
+## Git 상태 스냅샷
+
+- **Branch**: `{branch-name}`
+- **PR**: #{N} — {title}
+- **Merge commit**: `{hash}`
+- **Merged at**: {ISO timestamp}
+- **Base branch**: main
+
+---
+
+## 다음 단계
+
+> **기록 시점**: {completed | retroactive}
+
+1. {제안 1}
+2. {제안 2}
+
+---
+
+## 에이전트 세션 ID
+
+| 역할 | 세션 ID | 설명 |
+|------|---------|------|
+| {role} | `{session_id}` | {description} |
+
+> 데이터 없음 표기 예시: `데이터 없음 (세션 추적 시작 전)`

--- a/.sisyphus/reports/docs-foundation.md
+++ b/.sisyphus/reports/docs-foundation.md
@@ -1,0 +1,112 @@
+# Completion Report: docs-foundation
+
+> **Phase**: 1
+> **Plan**: .sisyphus/plans/docs-foundation.md
+> **Status**: completed
+> **Period**: 2026-03-13 ~ 2026-03-13
+> **PR**: #2 (merged 2026-03-13T11:33:36Z)
+> **Issue**: #1
+
+---
+
+## 사용자 요청 원문
+
+> 1. "제품의 구체적인 기획을 하나씩 다 마크다운으로 작성하고 해당 기획을 확정지은 다음에 개발을 하도록 해서 확장성이랑 개발 용이성 그리고 컨텍스트를 잃는 환경이 없도록 만들자"
+> 
+> 2. (방향 수정) "피자를 한입에 먹으려 하지 말자. 최초 검증 가능한 방향들을 설정하고 해당 방향들이 워킹하는지 실제 개발 전에 진행할 수 있는 테스트 리스트를 만들어"
+
+---
+
+## 산출물
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `docs/00-index.md` | 신규 | 문서 인덱스 & AI 에이전트 라우팅 가이드 |
+| `docs/01-product-definition.md` | 신규 | 제품 정의 (포지셔닝, MVP, 핵심 원칙, 경쟁 분석) |
+| `docs/02-market-research.md` | 신규 | 시장 조사 (글로벌/한국 플랫폼 분석, 비즈니스 모델) |
+| `docs/03-steam-benchmarking.md` | 신규 | Steam 벤치마킹 (15개 요소 매핑, 알고리즘 원리) |
+| `docs/04-creator-insights.md` | 신규 | 크리에이터 인사이트 (배급 구조, 자격 증명 함정, 게이트키퍼 스택) |
+| `docs/05-audience-insights.md` | 신규 | 관객 인사이트 (발견 경로, 커뮤니티 분석, 수요 신호) |
+| `docs/06-validation-plan.md` | 신규 | 가설 검증 계획 (6개 가설, 6개 사전 검증 테스트, GO/NO-GO 매트릭스) |
+| `docs/07-technical-preliminary.md` | 신규 | 기술 사전 검토 (기술 스택, 비용 추정, 법률/권리 프레임워크) |
+| `docs/08-decision-log.md` | 신규 | 결정 기록부 (ADR 형식, DECIDED/OPEN 항목) |
+| `docs/feature-specs/` | 이동 | `docs/04-feature-specs/` → `docs/feature-specs/` (번호 충돌 해소) |
+
+### 커밋 이력
+
+| 해시 | 메시지 |
+|------|--------|
+| `27a596f` | docs(#1): set up documentation directory structure |
+| `e6415ba` | docs(#1): add product definition document |
+| `3632a31` | docs(#1): add market research document |
+| `2023feb` | docs(#1): add Steam benchmarking document |
+| `33a9a9c` | docs(#1): add creator insights document |
+| `48d1982` | docs(#1): add audience insights document |
+| `7854dea` | docs(#1): expand creator insights document to 100+ lines |
+| `c58a0a8` | docs(#1): add validation plan document |
+| `dd5f582` | docs(#1): add technical preliminary document |
+| `7b8c085` | docs(#1): add decision log document |
+| `6cd68c1` | docs(#1): fix decision marker format |
+| `04d8e45` | docs(#1): add master index document |
+| `cbb9eeb` | docs(#1): fix broken cross-references in decision log |
+| `b381823` | docs(#1): establish planning documentation foundation [MERGE] |
+
+---
+
+## 핵심 결정사항
+
+| 결정 | 상태 | 근거 요약 |
+|------|------|----------|
+| 문서 언어: 한국어 (기술 용어 병기 허용) | [DECIDED] | 팀 커뮤니케이션 기본 언어 |
+| 마커 시스템: [DECIDED] / [OPEN] / [HYPOTHESIS] | [DECIDED] | 결정 상태 추적 및 명확성 |
+| 메타데이터 헤더: status, last_updated, source | [DECIDED] | 문서 버전 관리 및 추적성 |
+| 교차참조 형식: → see docs/XX-name.md | [DECIDED] | 문서 간 내용 중복 제거 |
+| 소스 문서: .sisyphus/drafts/cinema-on-air-research.md | [DECIDED] | 단일 진실 공급원 (SSOT) |
+| Steam 벤치마킹 모델 채택 | [DECIDED] | CTR 기반 알고리즘 + 태그 매칭 시스템이 발견성 문제 해결에 적합 |
+| MVP 단계 소액 등록비 도입 (Steam Direct 방식) | [DECIDED] | 무분별한 업로드 방지 및 최소 품질 관리 |
+| 플랫폼 범위: "만든 후의 플랫폼" (배급/발견 집중) | [DECIDED] | 제작 도구 제외, 배급사 발굴 구조 우선 |
+| 기술 스택: Next.js + TypeScript | [DECIDED] | 확장성 및 개발 생산성 |
+| 타겟 시장: 한국 우선 → 글로벌 확장 | [DECIDED] | 로컬 시장 검증 후 확장 전략 |
+
+---
+
+## Git 상태 스냅샷
+
+- **Branch**: `1-docs-establish-planning-documentation-foundation`
+- **PR**: #2 — docs(#1): establish planning documentation foundation
+- **Merge commit**: `b381823`
+- **Merged at**: 2026-03-13T11:33:36Z
+- **Base branch**: main
+
+---
+
+## 다음 단계
+
+> **기록 시점**: retroactive (실제로 한 것 기준)
+
+1. **Phase 2 (Validation)**: 6개 핵심 가설 검증 테스트 실행
+   - H1 (공급): 필름메이커스/누갤/영화과 커뮤니티 설문 (50명 중 10명+ "올리겠다" 목표)
+   - H2 (수요): 랜딩페이지 + 대기자명단 + 뉴스레터 (5%+ 이메일 등록, 40%+ 오픈율 목표)
+   - H3 (발견): 100편 수동 태깅 → 시네필 10명 A/B 테스트 (만족도 2배+ 목표)
+   - H4 (리텐션): 뉴스레터 4주 리텐션 측정 (30%+ 연속 오픈 목표)
+   - H5 (배급사): 배급사/프로그래머 인터뷰 3~5건 (5명 중 3명+ "참고하겠다" 목표)
+   - H6 (등록비): H1 설문에 포함 (1만원 기준 60%+ 수용 목표)
+
+2. **GO/NO-GO 결정 매트릭스**:
+   - H1+H2 성공 → **GO** (플랫폼 개발 진행)
+   - H1만 성공 → **PIVOT** (감독 도구로 방향 전환)
+   - H2만 성공 → **PIVOT** (큐레이션 미디어로 방향 전환)
+   - 둘 다 실패 → **NO-GO** (프로젝트 중단)
+
+3. **Phase 3 (Development)**: 검증 결과 기반 MVP 개발 시작
+   - 기술 스택: Next.js + TypeScript
+   - 비디오 호스팅: Mux 또는 Cloudflare Stream (최종 선택 대기)
+   - 초기 기능: 영화 업로드, 스트리밍, 태그/큐레이션, 관객 지표 대시보드
+
+---
+
+## 에이전트 세션 ID
+
+| 역할 | 세션 ID | 설명 |
+|------|---------|------|
+| — | 데이터 없음 (세션 추적 시작 전 — Phase 4부터 세션 ID 추적 시작) | Phase 1은 수동 작업 기반, 에이전트 세션 기록 없음 |

--- a/.sisyphus/reports/infrastructure-research.md
+++ b/.sisyphus/reports/infrastructure-research.md
@@ -1,0 +1,86 @@
+# Completion Report: infrastructure-research
+
+> **Phase**: 3
+> **Plan**: .sisyphus/plans/infrastructure-research.md
+> **Status**: completed
+> **Period**: 2026-03-14 ~ 2026-03-14
+> **PR**: #6 (merged 2026-03-14T08:32:01Z)
+> **Issue**: #5
+
+---
+
+## 사용자 요청 원문
+
+> 1. "한국에서 독립영화 단편영화를 촬영하기 위해서 필요한 인프라들에 대한 정보를 최대한 많이 수집하기 위한 계획을 세워"
+> 
+> 2. "영화를 본 사람들은 또 영화를 만들 사람일 확률이 높음. 그래서 영화를 찍은 장소, 장비, 인력, 배급 등을 연계해서 하나의 생태계를 만들어야 함. 서비스는 투 사이드 앱 — **Pro Mode**(감독/크리에이터)와 **Enjoy Mode**(관객)로 나뉨"
+
+---
+
+## 산출물
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `docs/08-decision-log.md` | 수정 | ADR-009 SUPERSEDED로 변경, ADR-013 신설 (Pro Mode/Enjoy Mode Two-sided App) |
+| `docs/01-product-definition.md` | 수정 | Pro Mode/Enjoy Mode 개념 반영, Scope Boundaries 업데이트 |
+| `docs/04-creator-insights.md` | 수정 | 결정 마커 업데이트 (SUPERSEDED) |
+| `docs/00-index.md` | 수정 | 인프라 섹션 추가 |
+| `docs/infrastructure/00-index.md` | 신규 | 인프라 마스터 인덱스 |
+| `docs/infrastructure/01-equipment-rental.md` | 신규 | 장비 렌탈 리서치 |
+| `docs/infrastructure/02-filming-locations.md` | 신규 | 촬영 장소 리서치 |
+| `docs/infrastructure/03-crew-casting.md` | 신규 | 인력/캐스팅 리서치 |
+| `docs/infrastructure/04-post-production.md` | 신규 | 후반작업 리서치 |
+| `docs/infrastructure/05-education-workshop.md` | 신규 | 교육/워크숍 리서치 |
+| `docs/infrastructure/06-funding.md` | 신규 | 자금/펀딩 리서치 |
+| `docs/infrastructure/07-legal-admin.md` | 신규 | 법적/행정 리서치 |
+
+### 커밋 이력
+
+| 해시 | 메시지 |
+|------|--------|
+| `834abb2` | docs(#5): ADR-009 superseded, ADR-013 added (Two-sided App architecture) |
+| `da017ad` | docs(#5): reflect Pro Mode/Enjoy Mode two-sided app architecture in product definition |
+| `ff7373c` | docs(#5): update creator-insights decision marker to SUPERSEDED |
+| `fbb89f1` | chore(#5): initialize infrastructure-research plan and boulder.json |
+| `a88a79c` | docs(#5): add 7-category Korean indie film infrastructure research docs |
+| `bff44d1` | docs(#5): add infrastructure index and update master index |
+| `cf7d60f` | docs(#5): Korean indie film infrastructure map + Pro Mode ecosystem [MERGE] |
+
+---
+
+## 핵심 결정사항
+
+> **데이터 출처**: notepad 데이터 없음 — `.sisyphus/notepads/infrastructure-research/` 디렉토리 미존재. plan 파일 및 git log에서 추출.
+
+| 결정 | 상태 | 근거 요약 |
+|------|------|----------|
+| ADR-009 폐기: "만든 후의 플랫폼, 제작 도구 제외" | [SUPERSEDED] | Pro Mode/Enjoy Mode Two-sided App 전환으로 제작 인프라를 플랫폼 범위에 포함 |
+| ADR-013 신설: Pro Mode/Enjoy Mode Two-sided App 아키텍처 | [DECIDED] | 영화 관객→제작자 전환 생태계 구축, 7개 인프라 카테고리 직접 연계 |
+| 7개 인프라 카테고리 범위 확정 (장비, 장소, 인력, 후반, 교육, 자금, 법적/행정) | [DECIDED] | 한국 독립영화 제작 인프라 전수 조사 완료 |
+
+---
+
+## Git 상태 스냅샷
+
+- **Branch**: `5-research-korean-indie-short-film-infrastructure-map-+-pro-mode-ecosystem`
+- **PR**: #6 — docs(#5): Korean indie film infrastructure map + Pro Mode ecosystem
+- **Merge commit**: `cf7d60f`
+- **Merged at**: 2026-03-14T08:32:01Z
+- **Base branch**: main
+
+---
+
+## 다음 단계
+
+> **기록 시점**: retroactive
+
+Phase 4(viral-strategy)에서 Pro Mode 인프라 연계 전략 수립 및 가설 검증 실행. 7개 인프라 카테고리별 플랫폼 연동 시나리오 개발, 초기 사용자 테스트 계획 수립.
+
+---
+
+## 에이전트 세션 ID
+
+| 역할 | 세션 ID | 설명 |
+|------|---------|------|
+| — | 데이터 없음 (세션 추적 시작 전 — Phase 4부터 세션 ID 추적 시작) | Phase 3 완료 시점에는 세션 추적 미실시 |
+

--- a/.sisyphus/reports/validation.md
+++ b/.sisyphus/reports/validation.md
@@ -1,0 +1,74 @@
+# Completion Report: validation
+
+> **Phase**: 2
+> **Plan**: .sisyphus/plans/validation.md
+> **Status**: completed
+> **Period**: 2026-03-13 ~ 2026-03-13
+> **PR**: #4 (merged 2026-03-13T20:44:25+09:00)
+> **Issue**: #3
+
+---
+
+## 사용자 요청 원문
+
+> `docs/06-validation-plan.md`에 정의된 H1~H6 가설을 개발 없이 검증하기 위한 실행 도구(설문, 랜딩페이지 콘텐츠, 뉴스레터, 큐레이션 프로토타입, 인터뷰 가이드)를 제작한다.
+
+---
+
+## 산출물
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `docs/validation/h1-h6-survey.md` | 신규 | H1+H6 설문 문항 설계 (감독 대상 설문: 업로드 의향, 등록비 수용도) |
+| `docs/validation/h2-landing-page.md` | 신규 | H2 랜딩페이지 콘텐츠 초안 (헤드라인, 가치 제안, A/B 테스트 변형안) |
+| `docs/validation/h2-h4-newsletter-issue1.md` | 신규 | H2+H4 뉴스레터 1호 콘텐츠 초안 (제목, 추천 단편, 감독 소개, CTA) |
+| `docs/validation/h3-curation-prototype.md` | 신규 | H3 큐레이션 프로토타입 설계 (Notion DB 구조, 태그 분류 체계, 테스트 방법론) |
+| `docs/validation/h5-distributor-interview.md` | 신규 | H5 배급사 인터뷰 가이드 (인터뷰 대상 프로필, 15개 질문, 데이터 활용 의향 측정) |
+| `docs/validation/validation-results-template.md` | 신규 | 검증 결과 종합 보고서 템플릿 (H1~H6 결과 기록, GO/NO-GO 매트릭스) |
+| `docs/validation/00-index.md` | 신규 | 전체 검증 도구 목록 및 링크, 실행 순서 및 타임라인 |
+
+### 커밋 이력
+
+| 해시 | 메시지 |
+|------|--------|
+| `a874634` | feat(#3): add hypothesis validation execution toolkit (H1-H6) |
+
+---
+
+## 핵심 결정사항
+
+| 결정 | 상태 | 근거 요약 |
+|------|------|----------|
+| H1~H6 가설 검증을 위한 7개 실행 도구 제작 | [DECIDED] | 개발 없이 정성적 검증 데이터 수집 가능한 도구 세트 구성 |
+| Wave 1: 설문 + 랜딩페이지 (H1, H2, H6) | [DECIDED] | 감독 공급 의향과 사용자 수요 신호를 병렬로 검증 |
+| Wave 2: 뉴스레터 + 큐레이션 프로토타입 (H2, H3, H4) | [DECIDED] | 콘텐츠 전달 채널과 추천 알고리즘 효과 검증 |
+| Wave 3: B2B 인터뷰 (H5) | [DECIDED] | 배급사 데이터 활용 의향 정성 조사 |
+| 각 도구별 성공 기준 명시 | [DECIDED] | 검증 완료 후 GO/NO-GO 판단 기준 사전 정의 |
+
+---
+
+## Git 상태 스냅샷
+
+- **Branch**: `3-feat-execute-hypothesis-validation-plan-h1-h6`
+- **PR**: #4 — feat(#3): add hypothesis validation execution toolkit (H1-H6)
+- **Merge commit**: `e3d25a7`
+- **Merged at**: 2026-03-13T20:44:25+09:00
+- **Base branch**: main
+
+---
+
+## 다음 단계
+
+> **기록 시점**: retroactive
+
+1. Phase 3 (infrastructure-research) 실행: 한국 독립영화 생태계 인프라 조사 (이슈 #5)
+2. 검증 도구 실제 실행: H1~H6 가설에 대한 정성 데이터 수집 및 분석
+3. GO/NO-GO 판단: validation-results-template.md 기반 의사결정
+
+---
+
+## 에이전트 세션 ID
+
+| 역할 | 세션 ID | 설명 |
+|------|---------|------|
+| 실행 | `데이터 없음 (세션 추적 시작 전)` | Phase 4부터 세션 ID 추적 시작 |

--- a/.sisyphus/reports/viral-strategy.md
+++ b/.sisyphus/reports/viral-strategy.md
@@ -1,0 +1,89 @@
+# Completion Report: viral-strategy
+
+> **Phase**: 4
+> **Plan**: .sisyphus/plans/viral-strategy.md
+> **Status**: completed
+> **Period**: 2026-03-15 ~ 2026-03-15
+> **PR**: #8 (merged 2026-03-15T09:20:17Z)
+> **Issue**: #7
+
+---
+
+## 사용자 요청 원문
+
+1. "한국은 영화 유튜버들이 매우 많다. 너무 유명한 유튜버가 아니라 하꼬 (1000명 이상 구독자) 위주로 단편영화 플랫폼 홍보를 위한 바이럴 전략을 작성하기 위한 계획을 세워"
+
+2. "인디그라운드에 대해서도 조사하고 감독들이 영화를 제작하기 위해서 국내에서 지원받을 수 있는 사업들도 모두 조사해"
+
+3. "모든 문서 추가 및 기존 문서 변경에는 깃허브를 통해 버전관리를 해야함"
+
+---
+
+## 산출물
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `docs/09-viral-strategy.md` | 신규 | 하꼬 영화 유튜버 바이럴 확산 전략 리서치 (264줄) |
+| `docs/10-indiground-analysis.md` | 신규 | 인디그라운드 경쟁/파트너 양면 분석 (227줄) |
+| `docs/infrastructure/06-funding.md` | 수정 | 제작지원사업 보강 (282→336줄) |
+| `docs/00-index.md` | 수정 | 09/10 행 추가, 배제 조항 수정 |
+| `docs/02-market-research.md` | 수정 | 인디그라운드 교차참조 추가 |
+| `docs/infrastructure/00-index.md` | 수정 | 줄 수 업데이트 (1677→1731) |
+| `docs/08-decision-log.md` | 수정 | ADR-014 추가 |
+
+### 커밋 이력
+
+| 해시 | 메시지 |
+|------|--------|
+| `a705cdb` | docs(#7): add Indiground dual analysis (competitor + partner) |
+| `a6dab3c` | docs(#7): add viral marketing research with YouTuber collaboration strategy |
+| `0cbeca3` | docs(#7): expand funding docs with AI film support and newcomer-accessible programs |
+| `34aad15` | docs(#7): update indexes and cross-references for Phase 4 documents |
+
+---
+
+## 핵심 결정사항
+
+| 결정 | 상태 | 근거 요약 |
+|------|------|----------|
+| ADR-014: 인디그라운드를 경쟁자가 아닌 잠재 파트너로 포지셔닝 (B2B vs B2C) | [DECIDED] | 영진위 산하 공공기관으로서 배급 매칭 기능 제공, Wavve+인디그라운드 2022 협업 선례 존재 |
+| 09-viral-strategy.md를 "바이럴 확산 전략 리서치"로 프레이밍 (실행 계획 아님) | [DECIDED] | 00-index.md 배제 조항 "마케팅 및 홍보 실행 계획"과 구분하기 위해 리서치 성격 명확화 |
+| 하꼬 유튜버 범위: 1,000~50,000 (나노 1K~5K / 마이크로 5K~20K / 스몰 20K~50K) | [DECIDED] | 한국 영화 유튜버 시장 분석 결과, 최적 타겟 범위 및 세분화 기준 설정 |
+| 00-index.md 배제 조항: "마케팅 및 홍보 계획" → "마케팅 및 홍보 실행 계획"으로 수정 | [DECIDED] | 09-viral-strategy.md(리서치)와 실행 계획 구분 필요 |
+| 인디그라운드 서비스 수: 9개 (NOT 6) | [DECIDED] | 02-market-research.md의 9개 핵심 사업 영역이 정확한 기준 |
+| 06-funding.md 업데이트 정책: ADDITIVE ONLY (282줄 원본 보존, 신규 내용만 추가) | [DECIDED] | 기존 데이터 무결성 유지하면서 2026년 3월 기준 신규 지원사업 정보 보강 |
+
+---
+
+## Git 상태 스냅샷
+
+- **Branch**: `7-docs-phase-4-viral-strategy-+-indiground-analysis-+-funding-update`
+- **PR**: #8 — docs(#7): Phase 4 viral strategy + Indiground analysis + funding update
+- **Merge commit**: `d549a97`
+- **Merged at**: 2026-03-15T09:20:17Z
+- **Base branch**: main
+
+---
+
+## 다음 단계
+
+> **기록 시점**: retroactive
+
+Phase 4 완료 후 실제로 Phase 5 (completion-reports 시스템 구축)가 수행되었다. 당시 계획 가능했던 후속 단계:
+
+1. 하꼬 유튜버 협업 가설 검증 테스트 실행 (타겟 3개 카테고리 중 1개 선정 후 파일럿)
+2. Pro Mode MVP 개발 착수 (감독 인터뷰 접근권 기반 프리미엄 기능)
+3. 인디그라운드 B2B 파트너십 협상 개시 (배급 매칭 통합 검토)
+4. 제작지원사업 신청 프로세스 자동화 (신고증 불필요 7개 사업 우선)
+
+---
+
+## 에이전트 세션 ID
+
+| 역할 | 세션 ID | 설명 |
+|------|---------|------|
+| Orchestrator (Atlas) | `ses_31946f544ffeQUUrAWWMaP4ADY` | Phase 4 전체 조율 및 의사결정 |
+| T1: docs/09-viral-strategy.md | `ses_30f4154e6ffe62qhW1ITnXe6u5` | 바이럴 전략 문서 작성 (264줄) |
+| T2: docs/10-indiground-analysis.md | `ses_30f40a645ffe5oRvyShIkWDklI` | 인디그라운드 분석 문서 작성 (227줄) |
+| T3: docs/infrastructure/06-funding.md | `ses_30f3f7d6dffeZ17VcM3f28xXz0` | 펀딩 문서 업데이트 (282→336줄) |
+| T0: Issue + Branch 생성 | `ses_30f436cd1ffea6LxBR86GzrF9h` | GitHub 이슈 #7 + 브랜치 생성 |


### PR DESCRIPTION
## Summary
플랜 완료 시 마무리 레포트를 생성하는 시스템 구축. 세션 복구 + 작업 아카이빙 겸용.

## Files Added
- `.sisyphus/reports/_template.md` — 레포트 템플릿 (6개 필수 섹션)
- `.sisyphus/reports/README.md` — 프로세스 규약 (생성 시점: PR 머지 직후, 데이터 소스 매핑)
- `.sisyphus/reports/docs-foundation.md` — Phase 1 소급 레포트 (PR #2, 2026-03-13)
- `.sisyphus/reports/validation.md` — Phase 2 소급 레포트 (PR #4, 2026-03-13)
- `.sisyphus/reports/infrastructure-research.md` — Phase 3 소급 레포트 (PR #6, 2026-03-14)
- `.sisyphus/reports/viral-strategy.md` — Phase 4 소급 레포트 (PR #8, 2026-03-15)

## Key Design Decisions
- 자동화 = 코드가 아닌 **프로세스 규약** (모든 새 플랜의 마지막 태스크에 레포트 생성 포함)
- 데이터 없으면 `데이터 없음 ({이유})` 으로 정직하게 표기 (추정 금지)
- 기존 notepads/evidence/plans 파일 무변경 (additive only)

Closes #9